### PR TITLE
Add IsDefault, IsNotDefault operators

### DIFF
--- a/Assets/Scripts/Extensions.meta
+++ b/Assets/Scripts/Extensions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 12d8da5acb0fe4536a3f3e4d7863a389
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Extensions/DefaultCondition.cs
+++ b/Assets/Scripts/Extensions/DefaultCondition.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using UniRx;
+
+namespace ExtraUniRx
+{
+    // ReSharper disable once PartialTypeWithSinglePart 他のファイルでも同一クラスを拡張する
+    public static partial class UniRxExtension
+    {
+        public static IObservable<TSource> IsDefault<TSource>(this IObservable<TSource> source)
+        {
+            return source.Where(x => Equals(x, default(TSource)));
+        }
+
+        public static IObservable<TSource> IsDefault<TSource, TValue>(this IObservable<TSource> source, Func<TSource, TValue> selector)
+        {
+            return source.Where(x => Equals(x, default(TSource)) || Equals(selector(x), default(TValue)));
+        }
+
+        public static IObservable<TSource> IsNotDefault<TSource>(this IObservable<TSource> source)
+        {
+            return source.Where(x => !Equals(x, default(TSource)));
+        }
+
+        public static IObservable<TSource> IsNotDefault<TSource, TValue>(this IObservable<TSource> source, Func<TSource, TValue> selector)
+        {
+            return source.Where(x => !Equals(x, default(TSource)) && !Equals(selector(x), default(TValue)));
+        }
+    }
+}

--- a/Assets/Scripts/Extensions/DefaultCondition.cs.meta
+++ b/Assets/Scripts/Extensions/DefaultCondition.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b71975c667104af18be610a02edf4a80
+timeCreated: 1528368492

--- a/Assets/Tests/EditMode/Scripts/Extensions.meta
+++ b/Assets/Tests/EditMode/Scripts/Extensions.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 188eaed981244d8ab404896e1d924cd5
+timeCreated: 1528370865

--- a/Assets/Tests/EditMode/Scripts/Extensions/DefaultConditionTest.cs
+++ b/Assets/Tests/EditMode/Scripts/Extensions/DefaultConditionTest.cs
@@ -1,0 +1,61 @@
+﻿using NUnit.Framework;
+using UniRx;
+
+namespace ExtraUniRx.Extensions
+{
+    public class DefaultConditionTest
+    {
+        private class Stub
+        {
+            public bool Value { get; set; }
+        }
+
+        [Test]
+        public void BasicTest()
+        {
+            var intSubject = new Subject<int>();
+            var classSubject = new Subject<Stub>();
+            var stopper = new Subject<Unit>();
+            intSubject.IsDefault().Buffer(stopper).Subscribe(x => Assert.AreEqual(3, x.Count));
+            intSubject.IsNotDefault().Buffer(stopper).Subscribe(x => Assert.AreEqual(2, x.Count));
+            classSubject.IsDefault().Buffer(stopper).Subscribe(x => Assert.AreEqual(2, x.Count));
+            classSubject.IsNotDefault().Buffer(stopper).Subscribe(x => Assert.AreEqual(1, x.Count));
+
+            intSubject.OnNext(0);
+            intSubject.OnNext(1);
+            intSubject.OnNext(0);
+            intSubject.OnNext(1);
+            intSubject.OnNext(0);
+            classSubject.OnNext(null);
+            classSubject.OnNext(new Stub());
+            classSubject.OnNext(null);
+
+            stopper.OnNext(Unit.Default);
+        }
+
+        [Test]
+        public void SelectorTest()
+        {
+            var intSubject = new Subject<int>();
+            var classSubject = new Subject<Stub>();
+            var stopper = new Subject<Unit>();
+            // IsDefault は「元が default」か「Selector を通した結果が Default」ならば値を流す
+            intSubject.IsDefault(x => x * 10).Buffer(stopper).Subscribe(x => Assert.AreEqual(3, x.Count));
+            intSubject.IsDefault(x => x - 1).Buffer(stopper).Subscribe(x => Assert.AreEqual(5, x.Count));
+            intSubject.IsNotDefault(x => x * 10).Buffer(stopper).Subscribe(x => Assert.AreEqual(2, x.Count));
+            classSubject.IsDefault(x => x.Value).Buffer(stopper).Subscribe(x => Assert.AreEqual(2, x.Count));
+            classSubject.IsNotDefault(x => x.Value).Buffer(stopper).Subscribe(x => Assert.AreEqual(1, x.Count));
+
+            intSubject.OnNext(0);
+            intSubject.OnNext(1);
+            intSubject.OnNext(0);
+            intSubject.OnNext(1);
+            intSubject.OnNext(0);
+            classSubject.OnNext(null);
+            classSubject.OnNext(new Stub());
+            classSubject.OnNext(new Stub {Value = true});
+
+            stopper.OnNext(Unit.Default);
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Scripts/Extensions/DefaultConditionTest.cs
+++ b/Assets/Tests/EditMode/Scripts/Extensions/DefaultConditionTest.cs
@@ -43,9 +43,10 @@ namespace ExtraUniRx.Extensions
             intSubject.IsDefault(x => x * 10).Buffer(stopper).Subscribe(x => Assert.AreEqual(3, x.Count));
             intSubject.IsDefault(x => x - 1).Buffer(stopper).Subscribe(x => Assert.AreEqual(5, x.Count));
             intSubject.IsNotDefault(x => x * 10).Buffer(stopper).Subscribe(x => Assert.AreEqual(2, x.Count));
-            classSubject.IsDefault(x => x.Value).Buffer(stopper).Subscribe(x => Assert.AreEqual(2, x.Count));
+            classSubject.IsDefault(x => x.Value).Buffer(stopper).Subscribe(x => Assert.AreEqual(3, x.Count));
             classSubject.IsNotDefault(x => x.Value).Buffer(stopper).Subscribe(x => Assert.AreEqual(1, x.Count));
 
+            UnityEngine.Debug.Log(new Stub());
             intSubject.OnNext(0);
             intSubject.OnNext(1);
             intSubject.OnNext(0);
@@ -54,6 +55,7 @@ namespace ExtraUniRx.Extensions
             classSubject.OnNext(null);
             classSubject.OnNext(new Stub());
             classSubject.OnNext(new Stub {Value = true});
+            classSubject.OnNext(new Stub {Value = false});
 
             stopper.OnNext(Unit.Default);
         }

--- a/Assets/Tests/EditMode/Scripts/Extensions/DefaultConditionTest.cs.meta
+++ b/Assets/Tests/EditMode/Scripts/Extensions/DefaultConditionTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: e09705ce3cea4b84bddc7ea7658db363
+timeCreated: 1528370866

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -388,6 +388,7 @@ PlayerSettings:
   switchAllowsRuntimeAddOnContentInstall: 0
   switchDataLossConfirmation: 0
   switchSupportedNpadStyles: 3
+  switchNativeFsCacheSize: 32
   switchSocketConfigEnabled: 0
   switchTcpInitialSendBufferSize: 32
   switchTcpInitialReceiveBufferSize: 64
@@ -614,7 +615,7 @@ PlayerSettings:
       daydreamIconForeground: {fileID: 0}
       daydreamIconBackground: {fileID: 0}
   cloudServicesEnabled: {}
-  facebookSdkVersion: 
+  facebookSdkVersion: 7.9.4
   apiCompatibilityLevel: 2
   cloudProjectId: 
   projectName: 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ yarn add "umm-projects/extra_unirx#^1.0.0"
 
 ## Usage
 
+### TestObserver
+
 TestObserver is utility for testing observable.
 
-```
+```csharp
 var subject = new Subject<int>();
 var observer = new TestObserver<int>();
 
@@ -35,14 +37,56 @@ Assert.AreEqual(2, observer.OnNextValues[1]);
 Assert.AreEqual(1, observer.OnCompletedCount);
 ```
 
+### SubjectProperty
+
 SubjectProperty is like a ReactiveProperty, but it's Subject.
 It's IObserver & IObservable, and not holding latest value in stream.
 
-```
+```csharp
 var property = new SubjectProperty<int>();
 property.Subscribe(observer); // behave as IObservable
 observable.Subscribe(property); // behave as IObserver
 property.Value; // and it's easy to access value
+```
+
+### IsDefault(), IsNotDefault()
+
+IsDefault(), IsNotDefault() are operators for `IObservable<T>`.
+These operators stream values when the streamed value is default (or not default).
+
+```csharp
+var intSubject = new Subject<int>();
+intSubject.IsDefault().Subscribe(x => Debug.Log(x)); // 0
+intSubject.IsNotDefault().Subscribe(x => Debug.Log(x)); // 100
+intSubject.OnNext(0);
+intSubject.OnNext(100);
+
+var objectSubject = new Subject<AnyClass>();
+objectSubject.IsDefault().Subscribe(x => Debug.Log(x)); // "null"
+objectSubject.IsNotDefault().Subscribe(x => Debug.Log(x)); // "AnyClass"
+objectSubject.OnNext(null);
+objectSubject.OnNext(new AnyClass());
+```
+
+Both methods accept a selector as an argument to select values to determine.
+
+```csharp
+var intSubject = new Subject<int>();
+intSubject.IsDefault(x => x - 100).Subscribe(x => Debug.Log(x)); // 0
+intSubject.IsDefault(x => x - 100).Subscribe(x => Debug.Log(x)); // 0, 100
+intSubject.IsNotDefault(x => x - 100).Subscribe(x => Debug.Log(x)); // 100
+intSubject.OnNext(0);
+intSubject.OnNext(100);
+
+class AnyClass { bool Value; }
+
+var objectSubject = new Subject<AnyClass>();
+objectSubject.IsDefault().Subscribe(x => Debug.Log(x)); // null, "AnyClass"
+objectSubject.IsDefault().Subscribe(x => Debug.Log(x.Value)); // throw NullReferenceException in Subscribe()
+objectSubject.IsNotDefault().Subscribe(x => Debug.Log(x.Value)); // true
+objectSubject.OnNext(null);
+objectSubject.OnNext(new AnyClass() { Value = false });
+objectSubject.OnNext(new AnyClass() { Value = true });
 ```
 
 ## License


### PR DESCRIPTION
## What

* 流れてきた値が C# 的な意味で `default` かどうかを判定し、真のときのみ値を流すオペレータ
* その逆も実装

## Why

* 毎回 `.Where(x => x == default(x))` とか `.Where(x => x != null)` とか書くのが面倒だったので作りました