### PR TITLE
Add Cache(), CacheAll() operators

### DIFF
--- a/Assets/Scripts/Interfaces.meta
+++ b/Assets/Scripts/Interfaces.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d71ea1d28097478eb5a0e46614bdebbd
+timeCreated: 1529979944

--- a/Assets/Scripts/Interfaces/ICachedObservable.cs
+++ b/Assets/Scripts/Interfaces/ICachedObservable.cs
@@ -1,4 +1,8 @@
-﻿using UniRx;
+﻿#if (NET_4_6)
+using System;
+#else
+using UniRx;
+#endif
 
 namespace ExtraUniRx
 {

--- a/Assets/Scripts/Interfaces/ICachedObservable.cs
+++ b/Assets/Scripts/Interfaces/ICachedObservable.cs
@@ -1,0 +1,9 @@
+﻿using UniRx;
+
+namespace ExtraUniRx
+{
+    public interface ICachedObservable<TValue> : IObservable<TValue>
+    {
+        TValue Value { get; }
+    }
+}

--- a/Assets/Scripts/Interfaces/ICachedObservable.cs.meta
+++ b/Assets/Scripts/Interfaces/ICachedObservable.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 87ae760218754bf1b6310478412185f8
+timeCreated: 1529979944

--- a/Assets/Scripts/Operators.meta
+++ b/Assets/Scripts/Operators.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d5c891cd6c264a2583316f7446c175d3
+timeCreated: 1529893321

--- a/Assets/Scripts/Operators/Cache.cs
+++ b/Assets/Scripts/Operators/Cache.cs
@@ -32,15 +32,14 @@ namespace ExtraUniRx.Operators
 
         protected override IDisposable SubscribeCore(IObserver<TValue> observer, IDisposable cancel)
         {
-            var observable = Source;
             if (!HasSubscribedForCache)
             {
                 Source.Connect();
-                observable.Subscribe(x => CachedValue = x);
+                Source.Subscribe(x => CachedValue = x);
                 HasSubscribedForCache = true;
             }
 
-            var disposable = observable.Subscribe(observer.OnNext, observer.OnError);
+            var disposable = Source.Subscribe(observer.OnNext, observer.OnError);
             if (HasSetCachedValue)
             {
                 observer.OnNext(CachedValue);

--- a/Assets/Scripts/Operators/Cache.cs
+++ b/Assets/Scripts/Operators/Cache.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using ExtraUniRx.Operators;
+using UniRx;
+using UniRx.Operators;
+
+namespace ExtraUniRx.Operators
+{
+    public class CacheObservable<TValue> : OperatorObservableBase<TValue>
+    {
+        private IObservable<TValue> Source { get; set; }
+
+        private TValue cachedValue;
+
+        private TValue CachedValue
+        {
+            get { return cachedValue; }
+            set
+            {
+                cachedValue = value;
+                HasSetCachedValue = true;
+            }
+        }
+
+        private bool HasSetCachedValue { get; set; }
+
+        public CacheObservable(IObservable<TValue> source) : base(source.IsRequiredSubscribeOnCurrentThread())
+        {
+            Source = source;
+        }
+
+        private bool HasSubscribedForCache { get; set; }
+
+        protected override IDisposable SubscribeCore(IObserver<TValue> observer, IDisposable cancel)
+        {
+            var observable = Source;
+            if (!HasSubscribedForCache)
+            {
+                observable.Subscribe(x => CachedValue = x);
+                HasSubscribedForCache = true;
+            }
+
+            var disposable = observable.Subscribe(observer.OnNext, observer.OnError);
+            if (HasSetCachedValue)
+            {
+                observer.OnNext(CachedValue);
+            }
+
+            return disposable;
+        }
+    }
+}
+
+namespace ExtraUniRx
+{
+    public static partial class ObservableExtensions
+    {
+        public static IObservable<TValue> Cache<TValue>(this IObservable<TValue> source)
+        {
+            return new CacheObservable<TValue>(source);
+        }
+    }
+}

--- a/Assets/Scripts/Operators/Cache.cs
+++ b/Assets/Scripts/Operators/Cache.cs
@@ -7,7 +7,7 @@ namespace ExtraUniRx.Operators
 {
     public class CacheObservable<TValue> : OperatorObservableBase<TValue>
     {
-        private IObservable<TValue> Source { get; set; }
+        private IConnectableObservable<TValue> Source { get; set; }
 
         private TValue cachedValue;
 
@@ -25,7 +25,7 @@ namespace ExtraUniRx.Operators
 
         public CacheObservable(IObservable<TValue> source) : base(source.IsRequiredSubscribeOnCurrentThread())
         {
-            Source = source;
+            Source = source.Publish();
         }
 
         private bool HasSubscribedForCache { get; set; }
@@ -35,6 +35,7 @@ namespace ExtraUniRx.Operators
             var observable = Source;
             if (!HasSubscribedForCache)
             {
+                Source.Connect();
                 observable.Subscribe(x => CachedValue = x);
                 HasSubscribedForCache = true;
             }

--- a/Assets/Scripts/Operators/Cache.cs
+++ b/Assets/Scripts/Operators/Cache.cs
@@ -5,7 +5,7 @@ using UniRx.Operators;
 
 namespace ExtraUniRx.Operators
 {
-    public class CacheObservable<TValue> : OperatorObservableBase<TValue>
+    public class CacheObservable<TValue> : OperatorObservableBase<TValue>, ICachedObservable<TValue>
     {
         private IConnectableObservable<TValue> Source { get; set; }
 
@@ -19,6 +19,11 @@ namespace ExtraUniRx.Operators
                 cachedValue = value;
                 HasSetCachedValue = true;
             }
+        }
+
+        public TValue Value
+        {
+            get { return CachedValue; }
         }
 
         private bool HasSetCachedValue { get; set; }
@@ -99,7 +104,7 @@ namespace ExtraUniRx
 {
     public static partial class ObservableExtensions
     {
-        public static IObservable<TValue> Cache<TValue>(this IObservable<TValue> source)
+        public static ICachedObservable<TValue> Cache<TValue>(this IObservable<TValue> source)
         {
             return new CacheObservable<TValue>(source);
         }

--- a/Assets/Scripts/Operators/Cache.cs
+++ b/Assets/Scripts/Operators/Cache.cs
@@ -32,6 +32,7 @@ namespace ExtraUniRx.Operators
 
         protected override IDisposable SubscribeCore(IObserver<TValue> observer, IDisposable cancel)
         {
+            observer = new Cache(observer, cancel);
             if (!HasSubscribedForCache)
             {
                 Source.Connect();
@@ -46,6 +47,50 @@ namespace ExtraUniRx.Operators
             }
 
             return disposable;
+        }
+
+        private class Cache : OperatorObserverBase<TValue, TValue>
+        {
+            public Cache(IObserver<TValue> observer, IDisposable cancel) : base(observer, cancel)
+            {
+            }
+
+            public override void OnNext(TValue value)
+            {
+                try
+                {
+                    observer.OnNext(value);
+                }
+                catch
+                {
+                    Dispose();
+                    throw;
+                }
+            }
+
+            public override void OnError(Exception error)
+            {
+                try
+                {
+                    observer.OnError(error);
+                }
+                finally
+                {
+                    Dispose();
+                }
+            }
+
+            public override void OnCompleted()
+            {
+                try
+                {
+                    observer.OnCompleted();
+                }
+                finally
+                {
+                    Dispose();
+                }
+            }
         }
     }
 }

--- a/Assets/Scripts/Operators/Cache.cs.meta
+++ b/Assets/Scripts/Operators/Cache.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 32d964550a7446a6a0488402adce2b7c
+timeCreated: 1529893322

--- a/Assets/Scripts/Operators/CacheAll.cs
+++ b/Assets/Scripts/Operators/CacheAll.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using ExtraUniRx.Operators;
+using UniRx;
+using UniRx.Operators;
+
+namespace ExtraUniRx.Operators
+{
+    public class CacheAllObservable<TValue> : OperatorObservableBase<TValue>
+    {
+        private IObservable<TValue> Source { get; set; }
+
+        private List<TValue> CachedValueList { get; set; }
+
+        public CacheAllObservable(IObservable<TValue> source) : base(source.IsRequiredSubscribeOnCurrentThread())
+        {
+            Source = source;
+            CachedValueList = new List<TValue>();
+        }
+
+        private bool HasSubscribedForCache { get; set; }
+
+        protected override IDisposable SubscribeCore(IObserver<TValue> observer, IDisposable cancel)
+        {
+            var observable = Source;
+            if (!HasSubscribedForCache)
+            {
+                observable.Subscribe(CachedValueList.Add);
+                HasSubscribedForCache = true;
+            }
+            var disposable = observable.Subscribe(observer.OnNext, observer.OnError);
+            if (CachedValueList.Any())
+            {
+                CachedValueList.ForEach(observer.OnNext);
+            }
+
+            return disposable;
+        }
+    }
+}
+
+namespace ExtraUniRx
+{
+    public static partial class ObservableExtensions
+    {
+        public static IObservable<TValue> CacheAll<TValue>(this IObservable<TValue> source)
+        {
+            return new CacheAllObservable<TValue>(source);
+        }
+    }
+}

--- a/Assets/Scripts/Operators/CacheAll.cs
+++ b/Assets/Scripts/Operators/CacheAll.cs
@@ -7,11 +7,16 @@ using UniRx.Operators;
 
 namespace ExtraUniRx.Operators
 {
-    public class CacheAllObservable<TValue> : OperatorObservableBase<TValue>
+    public class CacheAllObservable<TValue> : OperatorObservableBase<TValue>, ICachedObservable<TValue>
     {
         private IConnectableObservable<TValue> Source { get; set; }
 
         private List<TValue> CachedValueList { get; set; }
+
+        public TValue Value
+        {
+            get { return CachedValueList.LastOrDefault(); }
+        }
 
         public CacheAllObservable(IObservable<TValue> source) : base(source.IsRequiredSubscribeOnCurrentThread())
         {
@@ -89,7 +94,7 @@ namespace ExtraUniRx
 {
     public static partial class ObservableExtensions
     {
-        public static IObservable<TValue> CacheAll<TValue>(this IObservable<TValue> source)
+        public static ICachedObservable<TValue> CacheAll<TValue>(this IObservable<TValue> source)
         {
             return new CacheAllObservable<TValue>(source);
         }

--- a/Assets/Scripts/Operators/CacheAll.cs
+++ b/Assets/Scripts/Operators/CacheAll.cs
@@ -9,13 +9,13 @@ namespace ExtraUniRx.Operators
 {
     public class CacheAllObservable<TValue> : OperatorObservableBase<TValue>
     {
-        private IObservable<TValue> Source { get; set; }
+        private IConnectableObservable<TValue> Source { get; set; }
 
         private List<TValue> CachedValueList { get; set; }
 
         public CacheAllObservable(IObservable<TValue> source) : base(source.IsRequiredSubscribeOnCurrentThread())
         {
-            Source = source;
+            Source = source.Publish();
             CachedValueList = new List<TValue>();
         }
 
@@ -26,6 +26,7 @@ namespace ExtraUniRx.Operators
             var observable = Source;
             if (!HasSubscribedForCache)
             {
+                Source.Connect();
                 observable.Subscribe(CachedValueList.Add);
                 HasSubscribedForCache = true;
             }

--- a/Assets/Scripts/Operators/CacheAll.cs
+++ b/Assets/Scripts/Operators/CacheAll.cs
@@ -23,14 +23,13 @@ namespace ExtraUniRx.Operators
 
         protected override IDisposable SubscribeCore(IObserver<TValue> observer, IDisposable cancel)
         {
-            var observable = Source;
             if (!HasSubscribedForCache)
             {
                 Source.Connect();
-                observable.Subscribe(CachedValueList.Add);
+                Source.Subscribe(CachedValueList.Add);
                 HasSubscribedForCache = true;
             }
-            var disposable = observable.Subscribe(observer.OnNext, observer.OnError);
+            var disposable = Source.Subscribe(observer.OnNext, observer.OnError);
             if (CachedValueList.Any())
             {
                 CachedValueList.ForEach(observer.OnNext);

--- a/Assets/Scripts/Operators/CacheAll.cs.meta
+++ b/Assets/Scripts/Operators/CacheAll.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3067926aa32f42498e67e06245194549
+timeCreated: 1529914672

--- a/Assets/Scripts/SubjectProperty.cs
+++ b/Assets/Scripts/SubjectProperty.cs
@@ -36,6 +36,8 @@ namespace ExtraUniRx
 
         private ISubject<TValue> Subject = new Subject<TValue>();
 
+        private IObservable<TValue> Source { get; set; }
+
         public void OnCompleted()
         {
             this.Subject.OnCompleted();
@@ -53,7 +55,20 @@ namespace ExtraUniRx
 
         public IDisposable Subscribe(IObserver<TValue> observer)
         {
+            Source?.Subscribe(observer);
             return this.Subject.Subscribe(observer);
+        }
+
+        public SubjectProperty()
+        {
+        }
+
+        public SubjectProperty(IObservable<TValue> source) : this()
+        {
+            Source = source
+                .Do(OnNext)
+                .DoOnError(OnError)
+                .DoOnCompleted(OnCompleted);
         }
     }
 }

--- a/Assets/Scripts/SubjectProperty.cs
+++ b/Assets/Scripts/SubjectProperty.cs
@@ -36,7 +36,7 @@ namespace ExtraUniRx
 
         private ISubject<TValue> Subject = new Subject<TValue>();
 
-        private IObservable<TValue> Source { get; set; }
+        private IObservable<TValue> Source { get; }
 
         public void OnCompleted()
         {
@@ -55,7 +55,10 @@ namespace ExtraUniRx
 
         public IDisposable Subscribe(IObserver<TValue> observer)
         {
-            Source?.Subscribe(observer);
+            if (this.Source != default(IObservable<TValue>))
+            {
+                this.Source.Subscribe(observer);
+            }
             return this.Subject.Subscribe(observer);
         }
 
@@ -65,7 +68,7 @@ namespace ExtraUniRx
 
         public SubjectProperty(IObservable<TValue> source) : this()
         {
-            Source = source
+            this.Source = source
                 .Do(OnNext)
                 .DoOnError(OnError)
                 .DoOnCompleted(OnCompleted);

--- a/Assets/Scripts/SubjectProperty.cs
+++ b/Assets/Scripts/SubjectProperty.cs
@@ -55,8 +55,18 @@ namespace ExtraUniRx
         {
             return this.Subject.Subscribe(observer);
         }
+    }
 
+    public static class SubjectPropertyExtensions
+    {
+        public static SubjectProperty<TValue> ToSubjectProperty<TValue>(this IObservable<TValue> source)
         {
+            var subjectProperty = new SubjectProperty<TValue>();
+            source
+                .Do(subjectProperty.OnNext)
+                .DoOnError(subjectProperty.OnError)
+                .DoOnCompleted(subjectProperty.OnCompleted);
+            return subjectProperty;
         }
     }
 }

--- a/Assets/Scripts/SubjectProperty.cs
+++ b/Assets/Scripts/SubjectProperty.cs
@@ -51,27 +51,9 @@ namespace ExtraUniRx
             this.Value = value;
         }
 
-        private Action onSubscribe;
-
-        public Action OnSubscribe
-        {
-            private get { return onSubscribe ?? (onSubscribe = () => { }); }
-            set { onSubscribe = value; }
-        }
-
         public IDisposable Subscribe(IObserver<TValue> observer)
         {
-            return this.Subject.DoOnSubscribe(OnSubscribe).Subscribe(observer);
-        }
-    }
-
-    public static class SubjectPropertyExtensions
-    {
-        public static SubjectProperty<TValue> ToSubjectProperty<TValue>(this IObservable<TValue> source)
-        {
-            var subjectProperty = new SubjectProperty<TValue>();
-            subjectProperty.OnSubscribe = () => source.Subscribe(subjectProperty);
-            return subjectProperty;
+            return this.Subject.Subscribe(observer);
         }
     }
 }

--- a/Assets/Scripts/SubjectProperty.cs
+++ b/Assets/Scripts/SubjectProperty.cs
@@ -36,8 +36,6 @@ namespace ExtraUniRx
 
         private ISubject<TValue> Subject = new Subject<TValue>();
 
-        private IObservable<TValue> Source { get; }
-
         public void OnCompleted()
         {
             this.Subject.OnCompleted();
@@ -55,23 +53,10 @@ namespace ExtraUniRx
 
         public IDisposable Subscribe(IObserver<TValue> observer)
         {
-            if (this.Source != default(IObservable<TValue>))
-            {
-                this.Source.Subscribe(observer);
-            }
             return this.Subject.Subscribe(observer);
         }
 
-        public SubjectProperty()
         {
-        }
-
-        public SubjectProperty(IObservable<TValue> source) : this()
-        {
-            this.Source = source
-                .Do(OnNext)
-                .DoOnError(OnError)
-                .DoOnCompleted(OnCompleted);
         }
     }
 }

--- a/Assets/Tests/EditMode/AssemblyDefinition.asmdef
+++ b/Assets/Tests/EditMode/AssemblyDefinition.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Tests.EditMode",
+    "name": "umm@extra_unirx-Tests-EditMode",
     "references": [
         "umm@extra_unirx",
         "umm@unirx"

--- a/Assets/Tests/EditMode/Scripts/CacheOperatorTest.cs
+++ b/Assets/Tests/EditMode/Scripts/CacheOperatorTest.cs
@@ -1,0 +1,146 @@
+﻿using NUnit.Framework;
+using UniRx;
+
+namespace ExtraUniRx
+{
+    public class CacheOperatorTest
+    {
+        [Test]
+        public void CacheTest()
+        {
+            var subject = new Subject<Unit>();
+            var observable = subject.Select(_ => 1).Scan((a, b) => a + b).Share().Cache();
+
+            var testObserver1 = new TestObserver<int>();
+            var disposable1 = observable.Subscribe(testObserver1);
+
+            Assert.AreEqual(0, testObserver1.OnNextCount);
+
+            subject.OnNext(Unit.Default);
+
+            Assert.AreEqual(1, testObserver1.OnNextCount);
+            Assert.AreEqual(1, testObserver1.OnNextLastValue);
+
+            subject.OnNext(Unit.Default);
+            subject.OnNext(Unit.Default);
+
+            Assert.AreEqual(3, testObserver1.OnNextCount);
+            Assert.AreEqual(3, testObserver1.OnNextLastValue);
+
+            disposable1.Dispose();
+
+            var testObserver2 = new TestObserver<int>();
+            var disposable2 = observable.Subscribe(testObserver2);
+
+            Assert.AreEqual(1, testObserver2.OnNextCount);
+            Assert.AreEqual(3, testObserver2.OnNextLastValue);
+
+            subject.OnNext(Unit.Default);
+
+            Assert.AreEqual(2, testObserver2.OnNextCount);
+            Assert.AreEqual(4, testObserver2.OnNextLastValue);
+
+            disposable2.Dispose();
+
+            subject.OnNext(Unit.Default);
+            subject.OnNext(Unit.Default);
+
+            var testObserver3 = new TestObserver<int>();
+            var disposable3 = observable.Subscribe(testObserver3);
+
+            Assert.AreEqual(1, testObserver3.OnNextCount);
+            Assert.AreEqual(6, testObserver3.OnNextLastValue);
+
+            subject.OnNext(Unit.Default);
+
+            Assert.AreEqual(2, testObserver3.OnNextCount);
+            Assert.AreEqual(7, testObserver3.OnNextLastValue);
+
+            disposable3.Dispose();
+
+            subject.OnCompleted();
+
+            var testObserver4 = new TestObserver<int>();
+            var disposable4 = observable.Subscribe(testObserver4);
+
+            Assert.AreEqual(1, testObserver4.OnNextCount);
+            Assert.AreEqual(7, testObserver4.OnNextLastValue);
+
+            subject.OnNext(Unit.Default);
+
+            Assert.AreEqual(1, testObserver4.OnNextCount);
+            Assert.AreEqual(7, testObserver4.OnNextLastValue);
+
+            disposable4.Dispose();
+        }
+
+        [Test]
+        public void CacheAllTest()
+        {
+            var subject = new Subject<Unit>();
+            var observable = subject.Select(_ => 1).Scan((a, b) => a + b).Share().CacheAll();
+
+            var testObserver1 = new TestObserver<int>();
+            var disposable1 = observable.Subscribe(testObserver1);
+
+            Assert.AreEqual(0, testObserver1.OnNextCount);
+
+            subject.OnNext(Unit.Default);
+
+            Assert.AreEqual(1, testObserver1.OnNextCount);
+            Assert.AreEqual(1, testObserver1.OnNextLastValue);
+
+            subject.OnNext(Unit.Default);
+            subject.OnNext(Unit.Default);
+
+            Assert.AreEqual(3, testObserver1.OnNextCount);
+            Assert.AreEqual(3, testObserver1.OnNextLastValue);
+
+            disposable1.Dispose();
+
+            var testObserver2 = new TestObserver<int>();
+            var disposable2 = observable.Subscribe(testObserver2);
+
+            Assert.AreEqual(3, testObserver2.OnNextCount);
+            Assert.AreEqual(3, testObserver2.OnNextLastValue);
+
+            subject.OnNext(Unit.Default);
+
+            Assert.AreEqual(4, testObserver2.OnNextCount);
+            Assert.AreEqual(4, testObserver2.OnNextLastValue);
+
+            disposable2.Dispose();
+
+            subject.OnNext(Unit.Default);
+            subject.OnNext(Unit.Default);
+
+            var testObserver3 = new TestObserver<int>();
+            var disposable3 = observable.Subscribe(testObserver3);
+
+            Assert.AreEqual(6, testObserver3.OnNextCount);
+            Assert.AreEqual(6, testObserver3.OnNextLastValue);
+
+            subject.OnNext(Unit.Default);
+
+            Assert.AreEqual(7, testObserver3.OnNextCount);
+            Assert.AreEqual(7, testObserver3.OnNextLastValue);
+
+            disposable3.Dispose();
+
+            subject.OnCompleted();
+
+            var testObserver4 = new TestObserver<int>();
+            var disposable4 = observable.Subscribe(testObserver4);
+
+            Assert.AreEqual(7, testObserver4.OnNextCount);
+            Assert.AreEqual(7, testObserver4.OnNextLastValue);
+
+            subject.OnNext(Unit.Default);
+
+            Assert.AreEqual(7, testObserver4.OnNextCount);
+            Assert.AreEqual(7, testObserver4.OnNextLastValue);
+
+            disposable4.Dispose();
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Scripts/CacheOperatorTest.cs
+++ b/Assets/Tests/EditMode/Scripts/CacheOperatorTest.cs
@@ -9,7 +9,7 @@ namespace ExtraUniRx
         public void CacheTest()
         {
             var subject = new Subject<Unit>();
-            var observable = subject.Select(_ => 1).Scan((a, b) => a + b).Share().Cache();
+            var observable = subject.Select(_ => 1).Scan((a, b) => a + b).Cache();
 
             var testObserver1 = new TestObserver<int>();
             var disposable1 = observable.Subscribe(testObserver1);
@@ -78,7 +78,7 @@ namespace ExtraUniRx
         public void CacheAllTest()
         {
             var subject = new Subject<Unit>();
-            var observable = subject.Select(_ => 1).Scan((a, b) => a + b).Share().CacheAll();
+            var observable = subject.Select(_ => 1).Scan((a, b) => a + b).CacheAll();
 
             var testObserver1 = new TestObserver<int>();
             var disposable1 = observable.Subscribe(testObserver1);

--- a/Assets/Tests/EditMode/Scripts/CacheOperatorTest.cs.meta
+++ b/Assets/Tests/EditMode/Scripts/CacheOperatorTest.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8ba500cf9c5e440a9591971609ce4641
+timeCreated: 1529895797

--- a/Assets/Tests/EditMode/Scripts/SubjectPropertyTest.cs
+++ b/Assets/Tests/EditMode/Scripts/SubjectPropertyTest.cs
@@ -24,13 +24,13 @@ namespace ExtraUniRx
             var property = new SubjectProperty<int>();
             var observer = new TestObserver<int>();
             property.Subscribe(observer);
-            
+
             Assert.AreEqual(0, observer.OnNextCount);
             property.Value = 10;
-            
+
             Assert.AreEqual(1, observer.OnNextCount);
             Assert.AreEqual(10, observer.OnNextLastValue);
-            
+
             property.Value = 20;
             Assert.AreEqual(2, observer.OnNextCount);
             Assert.AreEqual(20, observer.OnNextLastValue);
@@ -38,12 +38,34 @@ namespace ExtraUniRx
             var observer2 = new TestObserver<int>();
             property.Subscribe(observer2);
             Assert.AreEqual(0, observer2.OnNextCount);
-            
+
             property.Value = 30;
             Assert.AreEqual(1, observer2.OnNextCount);
             Assert.AreEqual(30, observer2.OnNextLastValue);
             Assert.AreEqual(3, observer.OnNextCount);
             Assert.AreEqual(30, observer.OnNextLastValue);
+        }
+
+        [Test]
+        public void ToSubjectPropertyTest()
+        {
+            var value = 0;
+            var source = Observable.Return(0).Do(_ => value++);
+
+            // Subscribe していないので発火していないはず
+            Assert.AreEqual(0, value);
+
+            // ToSubjectProperty() 時点では発火しない
+            var subjectProperty = source.ToSubjectProperty();
+            Assert.AreEqual(0, value);
+
+            // Subscribe により発火
+            subjectProperty.Subscribe();
+            Assert.AreEqual(1, value);
+
+            // Subscribe 毎に Source の Subscribe が実行される
+            subjectProperty.Subscribe();
+            Assert.AreEqual(2, value);
         }
     }
 }

--- a/Assets/Tests/EditMode/Scripts/SubjectPropertyTest.cs
+++ b/Assets/Tests/EditMode/Scripts/SubjectPropertyTest.cs
@@ -45,27 +45,5 @@ namespace ExtraUniRx
             Assert.AreEqual(3, observer.OnNextCount);
             Assert.AreEqual(30, observer.OnNextLastValue);
         }
-
-        [Test]
-        public void ToSubjectPropertyTest()
-        {
-            var value = 0;
-            var source = Observable.Return(0).Do(_ => value++);
-
-            // Subscribe していないので発火していないはず
-            Assert.AreEqual(0, value);
-
-            // ToSubjectProperty() 時点では発火しない
-            var subjectProperty = source.ToSubjectProperty();
-            Assert.AreEqual(0, value);
-
-            // Subscribe により発火
-            subjectProperty.Subscribe();
-            Assert.AreEqual(1, value);
-
-            // Subscribe 毎に Source の Subscribe が実行される
-            subjectProperty.Subscribe();
-            Assert.AreEqual(2, value);
-        }
     }
 }


### PR DESCRIPTION
## What

* Add `.Cache()`, `.CacheAll()` operators into `IObservable<T>`

## Why

* I wanted an operator what can cache the value and perform delayed firing stream.

## Usage

```csharp
var www = ObservableWWW.Get("https://www.google.com/");

var sp = www.Cache(); // www stream does not fire at this time

sp.Subscribe(); // Fire both stream
```